### PR TITLE
Remove Python2.6

### DIFF
--- a/mate-base/mate-menus/mate-menus-1.12.0.ebuild
+++ b/mate-base/mate-menus/mate-menus-1.12.0.ebuild
@@ -4,7 +4,7 @@ EAPI="5"
 
 GCONF_DEBUG="no"
 GNOME2_LA_PUNT="yes"
-PYTHON_COMPAT=( python2_{6,7} )
+PYTHON_COMPAT=python2_7
 
 inherit gnome2 python-r1
 


### PR DESCRIPTION
Release notes explicitly say that python 2.7 is required